### PR TITLE
Never push BS (backspace) character to `text` in the gpu_cache example

### DIFF
--- a/examples/gpu_cache.rs
+++ b/examples/gpu_cache.rs
@@ -226,7 +226,7 @@ Feel free to type out some text, and delete it with Backspace. You can also try 
             match event {
                 glutin::Event::KeyboardInput(_, _, Some(glutin::VirtualKeyCode::Escape)) |
                 glutin::Event::Closed => break 'main,
-                glutin::Event::ReceivedCharacter(c) => if c != '\u{7f}' {
+                glutin::Event::ReceivedCharacter(c) => if c != '\u{7f}' && c != '\u{8}' {
                     text.push(c);
                 },
                 glutin::Event::KeyboardInput(


### PR DESCRIPTION
Backspace didn't work correctly because the example code pushes `\u{8}` at [line 230](https://github.com/dylanede/rusttype/blob/6aa3bfa32f5db0aff8df0e882fd6fc706e0b0fff/examples/gpu_cache.rs#L230) and then removes it at [line 236](https://github.com/dylanede/rusttype/blob/6aa3bfa32f5db0aff8df0e882fd6fc706e0b0fff/examples/gpu_cache.rs#L236).

This PR prevent appending BS character (`\u{8}`) to `text`, and enables Backspace key to work correctly.