### PR TITLE
Remove dependency to `ndarray` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ exclude = ["examples/*.ttf"]
 [dependencies]
 arrayvec = "0.3.13"
 stb_truetype = "0.2.0"
-ndarray = "0.3"
 linked-hash-map = "0.0.9"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,6 @@
 //!   have its own identifying number unique to the font, its ID.
 extern crate arrayvec;
 extern crate stb_truetype;
-extern crate ndarray;
 extern crate linked_hash_map;
 
 mod geometry;


### PR DESCRIPTION
`ndarray` crate is used only in `gpu_cache` module, and the module uses `ndarray` only for 2D array of `u8` type.
This commit implements `ByteArray2d` struct instead of `OwnedArray<u8, (Ix, Ix)>` to use, and remove dependency to `ndarray` crate.

At present, [the newest version of `ndarray` crate](https://crates.io/crates/ndarray) is 0.6.0 and some API has changed.
But ndarray-0.6.0 uses `#[deprecated]` attribute and cannot compile with rustc-1.8.0 or below.

I think this is a good chance to stop using `ndarray`, but if this PR is rejected, this crate should use newer `ndarray`.