### PR TITLE
Add a `FontCollection::into_fonts` method.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,12 +301,10 @@ pub struct IntoFontsIter<'a> {
 impl<'a> Iterator for IntoFontsIter<'a> {
     type Item = Font<'a>;
     fn next(&mut self) -> Option<Self::Item> {
-        tt::get_font_offset_for_index(&self.collection.0, self.next_index as i32)
-            .and_then(|o| tt::FontInfo::new(self.collection.0.clone(), o as usize))
-            .map(|info| {
-                self.next_index += 1;
-                Font { info: info }
-            })
+        self.collection.font_at(self.next_index).map(|font| {
+            self.next_index += 1;
+            font
+        })
     }
 }
 impl<'a> Font<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -286,6 +286,28 @@ impl<'a> FontCollection<'a> {
             .and_then(|o| tt::FontInfo::new(self.0.clone(), o as usize))
             .map(|info| Font { info: info })
     }
+    /// Converts `self` into an `Iterator` yielding each `Font` that exists within the collection.
+    pub fn into_fonts(self) -> IntoFontsIter<'a> {
+        IntoFontsIter {
+            collection: self,
+            next_index: 0,
+        }
+    }
+}
+pub struct IntoFontsIter<'a> {
+    next_index: usize,
+    collection: FontCollection<'a>,
+}
+impl<'a> Iterator for IntoFontsIter<'a> {
+    type Item = Font<'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        tt::get_font_offset_for_index(&self.collection.0, self.next_index as i32)
+            .and_then(|o| tt::FontInfo::new(self.collection.0.clone(), o as usize))
+            .map(|info| {
+                self.next_index += 1;
+                Font { info: info }
+            })
+    }
 }
 impl<'a> Font<'a> {
 


### PR DESCRIPTION
This is a convenience method that allows the user to convert a `FontCollection` into an iterator yielding each available font within the collection. I'm about to do something similar within conrod, but thought I might put it in a PR in case anyone else found it useful.

I would have used the `FontCollection::font_at` method to simplify the body of `IntoFontsIter::next`, but the lifetime of fonts returned from that method are bound to the instance of the `FontCollection` itself and not the internal SharedBytes (which is required by `IntoFontsIter`). I wasn't sure whether or not this was your intention, so I decided to leave the `FontCollection::font_at` method and duplicate the couple of lines that I needed instead.

Edit: looks like someone else has run into the `font_at` issue too #22. If you decide to accept it, I'd be happy to refactor this PR to use `font_at` rather than duplicating the logic :+1: