### PR TITLE
Use better (longer) lifetime as possible for `Font`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,7 +281,7 @@ impl<'a> FontCollection<'a> {
     }
     /// Gets the font at index `i` in the font collection, if it exists and is valid.
     /// The produced font borrows the font data that is either borrowed or owned by this font collection.
-    pub fn font_at(&self, i: usize) -> Option<Font> {
+    pub fn font_at(&self, i: usize) -> Option<Font<'a>> {
         tt::get_font_offset_for_index(&self.0, i as i32)
             .and_then(|o| tt::FontInfo::new(self.0.clone(), o as usize))
             .map(|info| Font { info: info })


### PR DESCRIPTION
Lifetime of a font object given by `FontCollection::font_at` is same as that of `SharedBytes` which `FontCollection` contains.

This change enables `Font` to exist without `FontCollection`.
example:
```rust
let font = {
    let font_data = include_bytes!("Arial Unicode.ttf");
    let collection = FontCollection::from_bytes(font_data.to_vec());
    collection.font_at(0).unwrap()
};
```